### PR TITLE
Use official viewable display size

### DIFF
--- a/config7/90-eDP1.conf
+++ b/config7/90-eDP1.conf
@@ -3,5 +3,5 @@ Section "Monitor"
 	Identifier  "eDP1"
 	VendorName  "Dell"
 	ModelName   "Infinity Display"
-	DisplaySize 296 166
+	DisplaySize 293.76 165.24
 EndSection


### PR DESCRIPTION
The original values were derived from the diagonal screen size, assuming square pixels.  Instead, these new dimensions are from [xps-13-9343-laptop_Reference%20Guide_en-us.pdf](http://downloads.dell.com/Manuals/all-products/esuprt_laptop/esuprt_xps_laptop/xps-13-9343-laptop_Reference%20Guide_en-us.pdf).
